### PR TITLE
Fix supabase import path

### DIFF
--- a/frontend/src/pages/DatasetExplorer/index.jsx
+++ b/frontend/src/pages/DatasetExplorer/index.jsx
@@ -6,7 +6,7 @@ import { CheckIcon, SelectorIcon } from "@heroicons/react/solid"
 import { DatabaseIcon } from "@heroicons/react/outline"
 import Navbar from "../../components/Navbar"
 import { DatasetExplorerAgent } from "./logic/DatasetExplorerAgent"
-import { supabase } from "../../../lib/supabaseClient"  // asegúrate de que esta ruta es la correcta
+import { supabase } from "../../supabaseClient";
 
 export default function DatasetExplorer() {
   // Estados


### PR DESCRIPTION
## Summary
- correct import path for supabase client in DatasetExplorer
- remove outdated reference to `lib/supabaseClient`

## Testing
- `npm run build` *(fails: `vite: Permission denied` because node modules were removed after build)*

------
https://chatgpt.com/codex/tasks/task_e_6854d6378998832fababd16024562997